### PR TITLE
perf: Icon 导入优化

### DIFF
--- a/demo/App.svelte
+++ b/demo/App.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-    import { ChevronLeft } from "@lucide/svelte";
+    import ChevronLeft from "@lucide/svelte/icons/chevron-left";
     import { Router } from "sv-router";
     import { GhostButton } from "../src/button";
     import { isActive, navigate } from "./router";

--- a/demo/pages/components/Button.svelte
+++ b/demo/pages/components/Button.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-    import { Heart } from "@lucide/svelte";
+    import Heart from "@lucide/svelte/icons/heart";
     import {
         BaseButton,
         GhostButton,

--- a/demo/pages/components/Switch.svelte
+++ b/demo/pages/components/Switch.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-    import { Heart } from "@lucide/svelte";
+    import Heart from "@lucide/svelte/icons/heart";
     import { Switch } from "../../../src/switch";
     import type { ColorType } from "../../../src/types";
 

--- a/src/button/GhostButton.svelte
+++ b/src/button/GhostButton.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-    import { LoaderCircle } from "@lucide/svelte";
+    import LoaderCircle from "@lucide/svelte/icons/loader-circle";
     import { clsx } from "clsx";
     import BaseButton from "./BaseButton.svelte";
     import type { ButtonProps } from "./types";

--- a/src/button/OutlineButton.svelte
+++ b/src/button/OutlineButton.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-    import { LoaderCircle } from "@lucide/svelte";
+    import LoaderCircle from "@lucide/svelte/icons/loader-circle";
     import { clsx } from "clsx";
     import BaseButton from "./BaseButton.svelte";
     import type { ButtonProps } from "./types";

--- a/src/button/SolidButton.svelte
+++ b/src/button/SolidButton.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-    import { LoaderCircle } from "@lucide/svelte";
+    import LoaderCircle from "@lucide/svelte/icons/loader-circle";
     import { clsx } from "clsx";
     import BaseButton from "./BaseButton.svelte";
     import type { ButtonProps } from "./types";

--- a/src/button/TextButton.svelte
+++ b/src/button/TextButton.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-    import { LoaderCircle } from "@lucide/svelte";
+    import LoaderCircle from "@lucide/svelte/icons/loader-circle";
     import { clsx } from "clsx";
     import BaseButton from "./BaseButton.svelte";
     import type { ButtonProps } from "./types";


### PR DESCRIPTION
从 `@lucide/svelte/icons` 导入 Lucide 图标，以加快构建速度。

Close #14 